### PR TITLE
The `get_time_based_greeting` method used a timezone-naive `datetime.…

### DIFF
--- a/hello_ai.py
+++ b/hello_ai.py
@@ -1,6 +1,6 @@
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 class AIGreeter:
@@ -32,7 +32,8 @@ class AIGreeter:
         # Note: This uses system local time. In production environments,
         # consider using timezone-aware datetime or pytz for consistent behavior
         try:
-            hour = datetime.now().hour
+            # Using UTC for consistent, timezone-aware time
+            hour = datetime.now(timezone.utc).hour
         except Exception:
             # Fallback if there are any datetime issues
             return "Hello! 👋"


### PR DESCRIPTION
…now()` object, causing inconsistent greetings in different environments.

This change updates the method to use `datetime.now(timezone.utc)`, ensuring that the time-based greetings are consistent and not dependent on the server's local time. The `timezone` object from the `datetime` module was imported to support this change.